### PR TITLE
Convert timestamp of mysql  to timestamptz of pgsql

### DIFF
--- a/dbsync/mysql2pgsql.c
+++ b/dbsync/mysql2pgsql.c
@@ -107,6 +107,9 @@ fetch_colmum_info(char *schemaname, char *tabname, MYSQL_RES *my_res, bool is_ta
 				break;
 
 			case MYSQL_TYPE_TIMESTAMP:
+				appendPQExpBuffer(ddl, "%s %s", field->org_name, "timestamptz");
+				col_type[i] = TIMESTAMPTZOID;
+				break;
 			case MYSQL_TYPE_DATE:
 			case MYSQL_TYPE_TIME:
 			case MYSQL_TYPE_DATETIME:


### PR DESCRIPTION
默认将mysql type timestamp转换成pgsql type timestamptz，以避免丢失mysql timestamp字段的时区信息