### PR TITLE
修复pgsql2pgsql两处bug

### DIFF
--- a/dbsync/pgsync.c
+++ b/dbsync/pgsync.c
@@ -358,6 +358,10 @@ db_sync_main(char *src, char *desc, char *local, int nthread)
 				fprintf(stderr, "create replication slot failed\n");
 				return 1;
 			}
+			else
+			{
+				th_hd.snapshot = snapshot;
+			}
 
 			th_hd.slot_name = hander->replication_slot;
 		}

--- a/dbsync/utils.c
+++ b/dbsync/utils.c
@@ -155,11 +155,15 @@ append_insert_colname(ALI_PG_DECODE_MESSAGE *msg, PQExpBuffer buffer, Decode_Tup
 	{
 		if (msg->attname[i] == NULL)
 		{
+			if (i+1 < tuple->natt && msg->attname[i+1] != NULL)
+			{
+				appendPQExpBuffer(buffer, ",");
+			}
 			continue;
 		}
 
 		appendPQExpBuffer(buffer, "%s", msg->attname[i]);
-		if(i != tuple->natt - 1)
+		if(i != tuple->natt - 1 && msg->attname[i+1] != NULL)
 		{
 			appendPQExpBuffer(buffer, ",");
 		}


### PR DESCRIPTION
1、若表最后的字段都是已删除的，原函数没有判断后续的字段是否是有效的，解析的插入sql字段列会多一个逗号。造成insert失败的问题
2、使用slot进行同步时，可能造成snapshot未能被记录到线程参数中，造成后续的表COPY时的snapshot非创建slot时的snapshot，而是最新的snapshot。引起insert主键冲突的问题。